### PR TITLE
Add delimiter option to gallery view

### DIFF
--- a/ckanext/gallery/plugins/gallery.py
+++ b/ckanext/gallery/plugins/gallery.py
@@ -50,7 +50,8 @@ class GalleryPlugin(p.SingletonPlugin):
             'schema': {
                 'image_field': [not_empty, is_datastore_field],
                 'image_plugin': [not_empty],
-                'image_title': [ignore_empty, is_datastore_field]
+                'image_title': [ignore_empty, is_datastore_field],
+                'image_delimiter': [ignore_empty],
             },
             'icon': 'picture',
             'iframed': False,

--- a/ckanext/gallery/plugins/image.py
+++ b/ckanext/gallery/plugins/image.py
@@ -1,8 +1,6 @@
-import json
 import ckan.plugins as p
-import ckan.lib.helpers as h
 from ckanext.gallery.plugins.interfaces import IGalleryImage
-from webhelpers.html import literal
+
 
 class GalleryImagePlugin(p.SingletonPlugin):
     """
@@ -25,17 +23,19 @@ class GalleryImagePlugin(p.SingletonPlugin):
 
     def get_images(self, field_value, record, data_dict):
         """
-        Get images from field
-        :param field_value:
-        :param record:
-        :param data_dict:
-        :return:
+        Get images from field value and returns them as a list of dicts specifying just the href.
+
+        :param field_value: the value of the record's image field
+        :param record: the record dict itself
+        :param data_dict: relevant data in a dict, currently we only use the resource_view contained within
+        :return: a list of dicts
         """
+        # retrieve the delimiter if there is one
+        delimiter = data_dict['resource_view'].get('image_delimiter', None)
+        if delimiter:
+            # split the text by the delimiter if we have one
+            images = field_value.split(delimiter)
+        else:
+            images = [field_value]
 
-        # Field value just contains the URL
-        return [
-            {
-                'href': field_value
-            }
-        ]
-
+        return [{'href': image.strip()} for image in images if image.strip()]

--- a/ckanext/gallery/theme/templates/gallery/form.html
+++ b/ckanext/gallery/theme/templates/gallery/form.html
@@ -8,6 +8,10 @@
   {{ form.info(_('Image type to use in the gallery.'), inline=True) }}
 {% endcall %}
 
+{% call form.input('image_delimiter', label=_('Image list delimiter'), value=data.image_delimiter, error=errors.image_delimiter) %}
+    {{ form.info(_('If your image field is the text type and contains a series of delimited image URLs instead of just a single one enter it here'), inline=True) }}
+{% endcall %}
+
 {% call form.select('image_title', label=_('Image title field'), options=[None] + datastore_fields, selected=data.image_title, error=errors.image_title) %}
   {{ form.info(_('Title field to use in the gallery.'), inline=True) }}
 {% endcall %}


### PR DESCRIPTION
Allows users to specify a delimiter when creating a gallery view. This delimiter is used to split the image field value up into multiple images.

Part of the work in https://github.com/NaturalHistoryMuseum/ckanext-nhm/pull/402