### PR TITLE
fix: preload ckan base to fix module error

### DIFF
--- a/ckanext/gallery/theme/assets/webassets.yml
+++ b/ckanext/gallery/theme/assets/webassets.yml
@@ -1,6 +1,9 @@
 main-js:
   output: ckanext-gallery/%(version)s_main.js
   filters: rjsmin
+  extra:
+    preload:
+      - base/main
   contents:
     - vendor/blueimp-gallery/js/blueimp-gallery.js
     - vendor/jquery-ui-1.12.1.custom/jquery-ui.js


### PR DESCRIPTION
We need to have the base/main available before the script runs so preload it.

Fixes #43 