### PR TITLE
IIIF image type view, refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _A CKAN extension for a dataset gallery view._
 # Overview
 
 <!--overview-start-->
-Adds a gallery view for resources on a CKAN instance. Two plugins are included in this extension: `gallery` and `gallery_image`.
+Adds a gallery view for resources on a CKAN instance. Three plugins are included in this extension: the main plugin (`gallery`) and two view plugins for specific image/data types (`gallery_image` and `gallery_iiif`).
 
 Based on [blueimp Gallery](https://blueimp.github.io/Gallery).
 

--- a/ckanext/gallery/plugins/iiif.py
+++ b/ckanext/gallery/plugins/iiif.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-gallery
+# Created by the Natural History Museum in London, UK
+
+from ckanext.gallery.plugins.interfaces import IGalleryImage
+
+from ckan.plugins import SingletonPlugin, implements, toolkit
+
+
+class GalleryIIIFPlugin(SingletonPlugin):
+    """
+    Implements the basic image field The URL of an image is present in a text field.
+    """
+
+    implements(IGalleryImage)
+
+    def image_info(self):
+        '''
+
+        :returns: If resource type is set, only dataset of that type will be available
+
+        '''
+        return {
+            'title': 'IIIF',
+            'resource_type': ['csv', 'tsv'],
+            'field_type': ['text'],
+        }
+
+    def get_images(self, field_value, record, data_dict):
+        """
+        Get images from field value and returns them as a list of dicts specifying just
+        the href.
+
+        :param field_value: the value of the record's image field
+        :param record: the record dict itself
+        :param data_dict: relevant data in a dict, currently we only use the resource_view contained within
+        :return: a list of dicts
+        """
+
+        images = []
+
+        # retrieve the delimiter if there is one
+        delimiter = data_dict['resource_view'].get('image_delimiter', None)
+        if delimiter:
+            # split the text by the delimiter if we have one
+            raw_images = field_value.split(delimiter)
+        else:
+            raw_images = [field_value]
+
+        title_field = data_dict['resource_view'].get('image_title', None)
+
+        for image in raw_images:
+            title = record.get(title_field)
+            image_base_url = image.strip().strip('/')
+
+            if not image_base_url:
+                continue
+
+            images.append(
+                {
+                    'href': f'{image_base_url}',
+                    'thumbnail': f'{image_base_url}/thumbnail',
+                    'download': f'{image_base_url}/original',
+                    'link': toolkit.url_for(
+                        'record.view',
+                        package_name=data_dict['package']['name'],
+                        resource_id=data_dict['resource']['id'],
+                        record_id=record['_id'],
+                    ),
+                    'description': title,
+                    'title': title,
+                    'record_id': record['_id'],
+                }
+            )
+
+        return images

--- a/ckanext/gallery/plugins/interfaces.py
+++ b/ckanext/gallery/plugins/interfaces.py
@@ -9,35 +9,29 @@ from ckan.plugins import interfaces
 
 class IGalleryImage(interfaces.Interface):
     """
-    IGallery plugin for displaying image field.
-
-    Can be extended - eg basic image in the gallery plugin
-    Or DwC image field in the NHM plugin
+    IGallery plugin for retrieving images from records.
     """
 
-    def info(self):
-        '''
-        :return: name, title, description
-        '''
-
-    def can_view(self, resource, field):
+    def image_info(self):
         """
-        Can this plugin view.
-
-        :param resource: param field:
-        :param field:
-        """
-
-    def thumbnail(self):
-        """
-        Thumbnail representation of the image.
+        Returns information about this plugin.
 
         :return:
         """
 
-    def image(self):
+    def get_images(self, field_value, record, data_dict):
         """
-        Full size representation of the image.
+        Retrieve images from a record and present them as a list of dicts. Valid output
+        fields for each image:
 
-        :return:
+            - href (main/preview URL; required)
+            - thumbnail (URL for a smaller version of the image)
+            - download (URL for the downloadable version of the image)
+            - link (e.g. record URL, displayed in popup viewer)
+            - copyright (licence information; HTML)
+            - description (displayed under the image thumbnail; HTML)
+            - title (title in the popup viewer and image alt)
+            - record_id
+
+        :return: list of dicts
         """

--- a/ckanext/gallery/theme/assets/js/gallery.js
+++ b/ckanext/gallery/theme/assets/js/gallery.js
@@ -1,7 +1,3 @@
-/**
- * Created by bens3 on 04/11/15.
- */
-
 ckan.module('gallery', function (jQuery, _) {
   var self;
 
@@ -20,9 +16,6 @@ ckan.module('gallery', function (jQuery, _) {
     _openLightbox: function (e) {
       var options = {
         index: $(this).data('index'),
-        //            onclose: function () {
-        //                self._hideDownloadTooltip()
-        //            },
         onslide: function () {
           self._onImageUpdate();
         },
@@ -39,7 +32,6 @@ ckan.module('gallery', function (jQuery, _) {
 
       // Update download link
       $('#blueimp-gallery a.gallery-control-download').attr('href', image.href);
-      //        $('#blueimp-gallery a.gallery-control-download').on('click', jQuery.proxy(self._downloadImage));
 
       if (image.copyright) {
         $gallery.find('.copyright').html(image.copyright);
@@ -52,24 +44,6 @@ ckan.module('gallery', function (jQuery, _) {
         $gallery.find('.gallery-control-link').hide();
       }
     },
-    //    _downloadImage: function(e){
-    //        self.downloadFile('http://www.nhm.ac.uk/services/media-store/asset/2d63e01b999aaa0581397d9e629e4bc9f30677a7/contents/preview', function(blob) {
-    //            saveAs(blob, "image.png");
-    //        });
-    //        e.stopPropagation();
-    //        return false;
-    //    },
-    //    downloadFile: function(url, success){
-    //        var xhr = new XMLHttpRequest();
-    //        xhr.open('GET', url, true);
-    //        xhr.responseType = "blob";
-    //        xhr.onreadystatechange = function () {
-    //            if (xhr.readyState == 4) {
-    //                if (success) success(xhr.response);
-    //            }
-    //        };
-    //       xhr.send(null);
-    //    },
     options: {
       images: [],
     },

--- a/ckanext/gallery/theme/assets/js/gallery.js
+++ b/ckanext/gallery/theme/assets/js/gallery.js
@@ -31,7 +31,10 @@ ckan.module('gallery', function (jQuery, _) {
       $gallery.data('image', image);
 
       // Update download link
-      $('#blueimp-gallery a.gallery-control-download').attr('href', image.href);
+      $('#blueimp-gallery a.gallery-control-download').attr(
+        'href',
+        image.download || image.href,
+      );
 
       if (image.copyright) {
         $gallery.find('.copyright').html(image.copyright);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ changelog = "https://github.com/NaturalHistoryMuseum/ckanext-gallery/blob/main/C
 [project.entry-points."ckan.plugins"]
 gallery = "ckanext.gallery.plugins.gallery:GalleryPlugin"
 gallery_image = "ckanext.gallery.plugins.image:GalleryImagePlugin"
+gallery_iiif = "ckanext.gallery.plugins.iiif:GalleryIIIFPlugin"
 
 
 [build-system]


### PR DESCRIPTION
- removes and rearranges some old code that was unnecessary or unclear
- can now set a separate URL as the download URL
- adds a new image type option for the view by adding a new plugin (`GalleryIIIFPlugin`)